### PR TITLE
Add getters for certain properties

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -48,6 +48,38 @@ class Client
         // These are the supported HTTP verbs
         $this->methods = ['delete', 'get', 'patch', 'post', 'put'];
     }
+    
+    /**
+     * @return string
+     */
+    public function getHost()
+    {
+        return $this->host;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+    
+    /**
+     * @return string|null
+     */
+    public function getVersion()
+    {
+        return $this->version;
+    }
+    
+    /**
+     * @return array
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
 
     /**
       * Make a new Client object

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -2,6 +2,8 @@
 
 namespace SendGrid\Test;
 
+use SendGrid\Client;
+
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
     /** @var MockClient */
@@ -10,7 +12,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     private $host;
     /** @var array */
     private $headers;
-    
+
     protected function setUp()
     {
         $this->host = 'https://localhost:4010';
@@ -20,7 +22,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         ];
         $this->client = new MockClient($this->host, $this->headers, '/v3', null);
     }
-    
+
     public function testConstructor()
     {
         $this->assertAttributeEquals($this->host, 'host', $this->client);
@@ -29,36 +31,69 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals([], 'path', $this->client);
         $this->assertAttributeEquals(['delete', 'get', 'patch', 'post', 'put'], 'methods', $this->client);
     }
-    
+
     public function test_()
     {
         $client = $this->client->_('test');
         $this->assertAttributeEquals(['test'], 'path', $client);
     }
-    
+
     public function test__call()
     {
         $client = $this->client->get();
         $this->assertAttributeEquals('https://localhost:4010/v3/', 'url', $client);
-      
+
         $queryParams = ['limit' => 100, 'offset' => 0];
         $client = $this->client->get(null, $queryParams);
         $this->assertAttributeEquals('https://localhost:4010/v3/?limit=100&offset=0', 'url', $client);
-      
+
         $requestBody = ['name' => 'A New Hope'];
         $client = $this->client->get($requestBody);
         $this->assertAttributeEquals($requestBody, 'requestBody', $client);
-      
+
         $requestHeaders = ['X-Mock: 200'];
         $client = $this->client->get(null, null, $requestHeaders);
         $this->assertAttributeEquals($requestHeaders, 'requestHeaders', $client);
-      
+
         $client = $this->client->version('/v4');
         $this->assertAttributeEquals('/v4', 'version', $client);
-      
+
         $client = $this->client->path_to_endpoint();
         $this->assertAttributeEquals(['path_to_endpoint'], 'path', $client);
         $client = $client->one_more_segment();
         $this->assertAttributeEquals(['path_to_endpoint', 'one_more_segment'], 'path', $client);
+    }
+
+    public function testGetHost()
+    {
+        $client = new Client('https://localhost:4010');
+        $this->assertSame('https://localhost:4010', $client->getHost());
+    }
+
+    public function testGetHeaders()
+    {
+        $client = new Client('https://localhost:4010', ['Content-Type: application/json', 'Authorization: Bearer SG.XXXX']);
+        $this->assertSame(['Content-Type: application/json', 'Authorization: Bearer SG.XXXX'], $client->getHeaders());
+
+        $client2 = new Client('https://localhost:4010', null);
+        $this->assertSame([], $client2->getHeaders());
+    }
+
+    public function testGetVersion()
+    {
+        $client = new Client('https://localhost:4010', null, '/v3');
+        $this->assertSame('/v3', $client->getVersion());
+
+        $client = new Client('https://localhost:4010', null, null);
+        $this->assertSame(null, $client->getVersion());
+    }
+
+    public function testGetPath()
+    {
+        $client = new Client('https://localhost:4010', null, null, ['/foo/bar']);
+        $this->assertSame(['/foo/bar'], $client->getPath());
+
+        $client = new Client('https://localhost:4010', null, null, null);
+        $this->assertSame([], $client->getPath());
     }
 }


### PR DESCRIPTION
Adding these getters helps other libraries, for instance sendgrid/sendgrid to check if constructor values have been set properly without using reflections on protected properties.
See [this pr in sendgrid/sendgrid ](https://github.com/sendgrid/sendgrid-php/pull/295) for some background on this topic.