### PR TITLE
Added curlOptions property to customize curl instance

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -29,26 +29,30 @@ class Client
     /** @var array */
     protected $path;
     /** @var array */
+    protected $curlOptions;
+    /** @var array */
     private $methods;
 
     /**
       * Initialize the client
       *
-      * @param string $host    the base url (e.g. https://api.sendgrid.com)
-      * @param array  $headers global request headers
-      * @param string $version api version (configurable)
-      * @param array  $path    holds the segments of the url path
+      * @param string $host        the base url (e.g. https://api.sendgrid.com)
+      * @param array  $headers     global request headers
+      * @param string $version     api version (configurable)
+      * @param array  $path        holds the segments of the url path
+      * @param array  $curlOptions extra options to set during curl initialization
       */
-    public function __construct($host, $headers = null, $version = null, $path = null)
+    public function __construct($host, $headers = null, $version = null, $path = null, $curlOptions = null)
     {
         $this->host = $host;
         $this->headers = $headers ?: [];
         $this->version = $version;
         $this->path = $path ?: [];
+        $this->curlOptions = $curlOptions ?: [];
         // These are the supported HTTP verbs
         $this->methods = ['delete', 'get', 'patch', 'post', 'put'];
     }
-    
+
     /**
      * @return string
      */
@@ -56,7 +60,7 @@ class Client
     {
         return $this->host;
     }
-    
+
     /**
      * @return array
      */
@@ -64,7 +68,7 @@ class Client
     {
         return $this->headers;
     }
-    
+
     /**
      * @return string|null
      */
@@ -72,13 +76,21 @@ class Client
     {
         return $this->version;
     }
-    
+
     /**
      * @return array
      */
     public function getPath()
     {
         return $this->path;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCurlOptions()
+    {
+        return $this->curlOptions;
     }
 
     /**
@@ -129,12 +141,12 @@ class Client
     {
         $curl = curl_init($url);
 
-        curl_setopt_array($curl, [
+        curl_setopt_array($curl, array_merge([
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => 1,
             CURLOPT_CUSTOMREQUEST => strtoupper($method),
             CURLOPT_SSL_VERIFYPEER => false,
-        ]);
+        ], $this->curlOptions));
 
         if (isset($headers)) {
             $this->headers = array_merge($this->headers, $headers);

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -20,7 +20,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
             'Content-Type: application/json',
             'Authorization: Bearer SG.XXXX'
         ];
-        $this->client = new MockClient($this->host, $this->headers, '/v3', null);
+        $this->client = new MockClient($this->host, $this->headers, '/v3', null, null);
     }
 
     public function testConstructor()
@@ -29,6 +29,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $this->assertAttributeEquals($this->headers, 'headers', $this->client);
         $this->assertAttributeEquals('/v3', 'version', $this->client);
         $this->assertAttributeEquals([], 'path', $this->client);
+        $this->assertAttributeEquals([], 'curlOptions', $this->client);
         $this->assertAttributeEquals(['delete', 'get', 'patch', 'post', 'put'], 'methods', $this->client);
     }
 
@@ -95,5 +96,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
         $client = new Client('https://localhost:4010', null, null, null);
         $this->assertSame([], $client->getPath());
+    }
+
+    public function testGetCurlOptions()
+    {
+        $client = new Client('https://localhost:4010', null, null, null, [CURLOPT_PROXY => '127.0.0.1:8080']);
+        $this->assertSame([CURLOPT_PROXY => '127.0.0.1:8080'], $client->getCurlOptions());
+
+        $client = new Client('https://localhost:4010', null, null, null, null);
+        $this->assertSame([], $client->getCurlOptions());
     }
 }


### PR DESCRIPTION
We are actually unable to add custom options to curl, such as timeout or proxy.

This PR add a new argument in the client's constructor that contains custom options, that are merged just after curl_init call.