### PR TITLE
Disable CURLOPT_FAILONERROR to properly set body for non 2xx-responses.

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -144,6 +144,7 @@ class Client
         curl_setopt_array($curl, array_merge([
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER => 1,
+            CURLOPT_FAILONERROR => false,
             CURLOPT_CUSTOMREQUEST => strtoupper($method),
             CURLOPT_SSL_VERIFYPEER => false,
         ], $this->curlOptions));


### PR DESCRIPTION
When making a request that returns in a status code other than 2xx, Curl would
output the response to STDOUT instead of part of the response in the `curl_exec`
call. This would cause the Response object returned from Client::makeRequest to
contain nothing in the body. By telling curl not to fail on error, the body is
left intact in the response from `curl_exec`, and the body is set as expected
in the Response object returned from Client::makeRequest.

This resolves the errors being output to screen as reported in sendgrid/sendgrid-php#321.