### PR TITLE
Pass the curlOptions to the client in buildClient

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -105,7 +105,7 @@ class Client
         if (isset($name)) {
             $this->path[] = $name;
         }
-        $client = new Client($this->host, $this->headers, $this->version, $this->path);
+        $client = new Client($this->host, $this->headers, $this->version, $this->path, $this->curlOptions);
         $this->path = [];
         return $client;
     }

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -35,8 +35,11 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function test_()
     {
-        $client = $this->client->_('test');
+        $client = new MockClient($this->host, $this->headers, '/v3', null, ['foo' => 'bar']);
+        $client = $client->_('test');
+
         $this->assertAttributeEquals(['test'], 'path', $client);
+        $this->assertAttributeEquals(['foo' => 'bar'], 'curlOptions', $client);
     }
 
     public function test__call()


### PR DESCRIPTION
The `curlOptions` was not passed to the client built through `buildClient`, so this fixes that.

(note ; I sent a CLA request just a few minutes ago, so it's pending...)