### PR TITLE
fixed return annotation

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -195,7 +195,7 @@ class Client
       * @param string $name name of the dynamic method call or HTTP verb
       * @param array  $args parameters passed with the method call
       *
-      * @return Client or Response object
+      * @return Client|Response object
       */
     public function __call($name, $args)
     {


### PR DESCRIPTION
In order for the return type to be properly understood by IDEs and documentation parsers or should be replaced with |