### PR TITLE
Adds unit test for checking year on licence

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 SendGrid, Inc.
+Copyright (c) 2012-2017 SendGrid, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/unit/LicenceYearTest.php
+++ b/test/unit/LicenceYearTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SendGrid\Test;
+
+class LicenceYearTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstructor()
+    {
+        $license = explode("\n", file_get_contents('./LICENSE.txt'));
+        $copyright = $license[2];
+
+        $year = date('Y');
+
+        $expected = "Copyright (c) 2012-{$year} SendGrid, Inc.";
+
+        $this->assertEquals($expected, $copyright);
+    }
+
+}

--- a/test/unit/LicenceYearTest.php
+++ b/test/unit/LicenceYearTest.php
@@ -6,7 +6,9 @@ class LicenceYearTest extends \PHPUnit_Framework_TestCase
 {
     public function testConstructor()
     {
-        $license = explode("\n", file_get_contents('./LICENSE.txt'));
+        $rootDir = __DIR__ . '/../..';
+
+        $license = explode("\n", file_get_contents("$rootDir/LICENSE.txt"));
         $copyright = $license[2];
 
         $year = date('Y');


### PR DESCRIPTION
Fixes #57 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
This PR adds a unit test for checking the year in the license.txt files matches the current year
