### PR TITLE
Add JsonSerializable type to phpDoc of $body parameter in makeRequest method

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -243,11 +243,11 @@ class Client
       * Make the API call and return the response. This is separated into
       * it's own function, so we can mock it easily for testing.
       *
-      * @param string $method       the HTTP verb
-      * @param string $url          the final url to call
-      * @param array  $body         request body
-      * @param array  $headers      any additional request headers
-      * @param bool   $retryOnLimit should retry if rate limit is reach?
+      * @param string                   $method       the HTTP verb
+      * @param string                   $url          the final url to call
+      * @param array|\JsonSerializable  $body         request body
+      * @param array                    $headers      any additional request headers
+      * @param bool                     $retryOnLimit should retry if rate limit is reach?
       *
       * @return Response object
       */


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

I have not added any documentation because I don't think it's necessary for this change. Also I haven't added any tests, because this type of issues can only be detected by static analysis on files using this package.

### Short description of what this PR does:

This PR updates phpDoc comment to reflect the code (not only array, but also `JsonSerializable` can be passed to `makeRequest` method). That allows usage of this package in projects  using [static analysis](https://github.com/phpstan/phpstan/) without the need of suppressing some error messages.