### PR TITLE
Fixed build url function to make arrays work with the api

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -163,9 +163,19 @@ class Client
     private function buildUrl($queryParams = null)
     {
         $path = '/' . implode('/', $this->path);
+        $additonalPath = '';
+
         if (isset($queryParams)) {
-            $path .= '?' . http_build_query($queryParams);
+            foreach ($queryParams as $paramName => $paramValue) {
+                if (is_array($paramValue)) {
+                    unset($queryParams[$paramName]);
+                    $additonalPath .= '&' . $paramName . '=' . implode('&' . $paramName . '=', $paramValue);
+                }
+            }
+
+            $path .= '?' . http_build_query($queryParams) . $additonalPath;
         }
+
         return sprintf('%s%s%s', $this->host, $this->version ?: '', $path);
     }
 


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
This PR fixes an issue that you can not send url parameters with the same name to buildUrl. This is required for the category statistics if you want to fetch multiple categories (https://sendgrid.com/docs/API_Reference/api_v3.html).