### PR TITLE
Don't overwrite headers set from upstream dependencies

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -192,7 +192,7 @@ class Client
         if (isset($headers)) {
             $headers = array_merge($this->headers, $headers);
         } else {
-            $headers = [];
+            $headers = $this->headers;
         }
 
         if (isset($body)) {


### PR DESCRIPTION
Fixes [issue 584](https://github.com/sendgrid/sendgrid-php/issues/584) in `sendgrid-php`.