### PR TITLE
Throw InvalidRequest exception on invalid CURL request

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ var_dump(
 );
 ```
 
+If there is an issues with the request, such as misconfigured CURL SSL options, an `InvalidRequest` will be thrown
+with message from CURL on why the request failed. Use the message as a hit to troubleshooting steps of your environment. 
+
 <a name="usage"></a>
 # Usage
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -13,6 +13,8 @@
 
 namespace SendGrid;
 
+use SendGrid\Exception\InvalidRequest;
+
 /**
  *
  * Class Client
@@ -453,6 +455,7 @@ class Client
      * @param bool   $retryOnLimit should retry if rate limit is reach?
      *
      * @return Response object
+     * @throws InvalidRequest
      */
     public function makeRequest($method, $url, $body = null, $headers = null, $retryOnLimit = false)
     {
@@ -462,6 +465,10 @@ class Client
 
         curl_setopt_array($channel, $options);
         $content = curl_exec($channel);
+
+        if ($content === false) {
+            throw new InvalidRequest(curl_error($channel), curl_errno($channel));
+        }
 
         $response = $this->parseResponse($channel, $content);
 

--- a/lib/Exception/InvalidRequest.php
+++ b/lib/Exception/InvalidRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * HTTP Client library
+ *
+ * @author    Matt Bernier <dx@sendgrid.com>
+ * @author    Elmer Thomas <dx@sendgrid.com>
+ * @copyright 2018 SendGrid
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ * @version   GIT: <git_id>
+ * @link      http://packagist.org/packages/sendgrid/php-http-client
+ */
+namespace SendGrid\Exception;
+
+use Throwable;
+
+/**
+ * Class InvalidHttpRequest
+ *
+ * Thrown when invalid payload was constructed, which could not reach SendGrid server.
+ *
+ * @package SendGrid\Exceptions
+ */
+class InvalidRequest extends \Exception
+{
+    public function __construct(
+        $message = "",
+        $code = 0,
+        Throwable $previous = null
+    ) {
+        $message = 'Could not send request to server. '.
+            'CURL error '.$code.': '.$message;
+        parent::__construct($message, $code, $previous);
+    }
+
+}

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -3,6 +3,7 @@
 namespace SendGrid\Test;
 
 use SendGrid\Client;
+use SendGrid\Exception\InvalidRequest;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
@@ -193,6 +194,14 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                 'Content-Type: application/json'
             ]
         ], $result);
+    }
+
+
+    public function testThrowExceptionOnInvalidCall()
+    {
+        $this->setExpectedException(InvalidRequest::class);
+        $client = new Client('invalid://url',['User-Agent: Custom-Client 1.0']);
+        $client->get();
     }
 
     /**


### PR DESCRIPTION
# Fixes # 
#90 
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Currently, if there are any issues with requests, the library exists silently with response code 0. This creates confusion about whether the problem was detected at SendGrid server or locally, what should be done next. This PR introduces an exception thrown with message from CURL about why actually request fails.
- Not doing a specific exception as outlined in #90 because
   1.  there are many reasons why request (SSL or not) could fail, and that was just a single example. No point replicating every possible CURL error into an exception.
   2. Difficult to unit test full working connection to replicate network conditions.
