### PR TITLE
Trigger an E_USER_ERROR whenever a curl request fails (#90)

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -415,6 +415,10 @@ class Client
         $headerSize = curl_getinfo($channel, CURLINFO_HEADER_SIZE);
         $statusCode = curl_getinfo($channel, CURLINFO_HTTP_CODE);
 
+        if ($statusCode === 0) {
+            trigger_error(curl_error($channel), E_USER_ERROR);
+        }
+
         $responseBody = substr($content, $headerSize);
 
         $responseHeaders = substr($content, 0, $headerSize);


### PR DESCRIPTION
# Fixes #90

This is one of three possible solutions to #90 (will submit and link the other two options shortly)

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- An `E_USER_ERROR` will be triggered if a curl request fails due to something like SSL verification - it's not catchable like #103, but is less of a BC break
