### PR TITLE
Support composer/ca-bundle fallback

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,9 @@
         "phpunit/phpunit": "~4.4",
         "squizlabs/php_codesniffer": "~2.0"
     },
+    "suggest": {
+        "composer/ca-bundle": "Including this library will ensure that a valid CA bundle is available for secure connections"
+    },
     "autoload": {
         "psr-4": {
             "SendGrid\\": "lib/"

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -367,6 +367,15 @@ class Client
         }
         $options[CURLOPT_HTTPHEADER] = $headers;
 
+        if (class_exists('\\Composer\\CaBundle\\CaBundle') && method_exists('\\Composer\\CaBundle\\CaBundle', 'getSystemCaRootBundlePath')) {
+            $caPathOrFile = \Composer\CaBundle\CaBundle::getSystemCaRootBundlePath();
+            if (is_dir($caPathOrFile) || (is_link($caPathOrFile) && is_dir(readlink($caPathOrFile)))) {
+                $options[CURLOPT_CAPATH] = $caPathOrFile;
+            } else {
+                $options[CURLOPT_CAINFO] = $caPathOrFile;
+            }
+        }
+
         return $options;
     }
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -415,6 +415,10 @@ class Client
         $headerSize = curl_getinfo($channel, CURLINFO_HEADER_SIZE);
         $statusCode = curl_getinfo($channel, CURLINFO_HTTP_CODE);
 
+        if ($statusCode === 0) {
+            throw new \RuntimeException(curl_error($channel));
+        }
+
         $responseBody = substr($content, $headerSize);
 
         $responseHeaders = substr($content, 0, $headerSize);
@@ -453,6 +457,8 @@ class Client
      * @param bool   $retryOnLimit should retry if rate limit is reach?
      *
      * @return Response object
+     *
+     * @throws \RuntimeException
      */
     public function makeRequest($method, $url, $body = null, $headers = null, $retryOnLimit = false)
     {
@@ -481,6 +487,8 @@ class Client
      * @param array $requests
      *
      * @return Response[]
+     *
+     * @throws \RuntimeException
      */
     public function makeAllRequests(array $requests = [])
     {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -415,10 +415,6 @@ class Client
         $headerSize = curl_getinfo($channel, CURLINFO_HEADER_SIZE);
         $statusCode = curl_getinfo($channel, CURLINFO_HTTP_CODE);
 
-        if ($statusCode === 0) {
-            throw new \RuntimeException(curl_error($channel));
-        }
-
         $responseBody = substr($content, $headerSize);
 
         $responseHeaders = substr($content, 0, $headerSize);
@@ -457,8 +453,6 @@ class Client
      * @param bool   $retryOnLimit should retry if rate limit is reach?
      *
      * @return Response object
-     *
-     * @throws \RuntimeException
      */
     public function makeRequest($method, $url, $body = null, $headers = null, $retryOnLimit = false)
     {
@@ -487,8 +481,6 @@ class Client
      * @param array $requests
      *
      * @return Response[]
-     *
-     * @throws \RuntimeException
      */
     public function makeAllRequests(array $requests = [])
     {

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -196,6 +196,16 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegExp /SSL certificate problem/i
+     */
+    public function testMakeRequestWithUntrustedRootCert()
+    {
+        $client = new Client('https://untrusted-root.badssl.com/');
+        $client->makeRequest('GET', 'https://untrusted-root.badssl.com/');
+    }
+
+    /**
      * @param object $obj
      * @param string $name
      * @param array $args

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -196,16 +196,6 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessageRegExp /SSL certificate problem/i
-     */
-    public function testMakeRequestWithUntrustedRootCert()
-    {
-        $client = new Client('https://untrusted-root.badssl.com/');
-        $client->makeRequest('GET', 'https://untrusted-root.badssl.com/');
-    }
-
-    /**
      * @param object $obj
      * @param string $name
      * @param array $args


### PR DESCRIPTION
# Fixes #90

This is one of three possible solutions to #90 (see #103 and #104).  This one can be included with either #103 or #104 if you'd like.

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- If `composer/ca-bundle` is installed, it'll use that to locate a CA bundle and configure curl to use that. This will be either the system's default, or Mozilla's if none is found
