### PR TITLE
only mention the lowest required PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All updates to this library is documented in our [CHANGELOG](https://github.com/
 
 ## Prerequisites
 
-- PHP version 5.6 or 7.0
+- PHP version 5.6 or higher
 
 ## Install with Composer
 


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added necessary documentation about the functionality in the appropriate .md file~
- [ ] ~I have added in line documentation to the code I modified~

### Short description of what this PR does:
- This PR makes sure the README mirrors what is actually required in the code. As per the [`composer.json`](https://github.com/sendgrid/php-http-client/blob/e9a04d949ee2d19938ab83dc100933a3b41a8ec7/composer.json), this library requires PHP 5.6 _or higher_. Let's not confuse users by only mentioning PHP 5.6 and 7.0 in the README.