### PR TITLE
feat: Build URL with multiple instances of the same param

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -50,6 +50,23 @@ echo $response->body();
 echo $response->headers();
 ```
 
+#### GET with array of values
+
+```
+$query_params = [
+    'aggregated_by' => 'month',
+    'subusers' => ['one', 'two', 'three'],
+    'start_date' => '2019-01-01',
+    'end_date' => '2019-01-31',
+];
+$request_headers = ['X-Mock: 200'];
+$retryOnLimit = true;
+$response = $client->subusers()->stats()->get(null, $query_params, $request_headers, $retryOnLimit);
+echo $response->statusCode();
+echo $response->body();
+echo $response->headers();
+```
+
 <a name="delete"></a>
 ## DELETE
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -352,7 +352,7 @@ class Client
     {
         $path = '/' . implode('/', $this->path);
         if (isset($queryParams)) {
-            $path .= '?' . http_build_query($queryParams);
+            $path .= '?' . preg_replace('/%5B(?:\d|[1-9]\d+)%5D=/', '=', http_build_query($queryParams));
         }
 
         return sprintf('%s%s%s', $this->host, $this->version ?: '', $path);

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -346,12 +346,15 @@ class Client
      *
      * @param array $queryParams an array of all the query parameters
      *
+     * Nested arrays will resolve to multiple instances of the same parameter
+     *
      * @return string
      */
     private function buildUrl($queryParams = null)
     {
         $path = '/' . implode('/', $this->path);
         if (isset($queryParams)) {
+            // Regex replaces `[0]=`, `[1]=`, etc. with `=`.
             $path .= '?' . preg_replace('/%5B(?:\d|[1-9]\d+)%5D=/', '=', http_build_query($queryParams));
         }
 

--- a/test/unit/ClientTest.php
+++ b/test/unit/ClientTest.php
@@ -218,6 +218,22 @@ class ClientTest extends TestCase
         $client->makeRequest('GET', 'https://untrusted-root.badssl.com/');
     }
 
+    public function testFormRepeatUrlArgs()
+    {
+        $client = new Client('https://localhost:4010');
+
+        $testParams = [
+          'thing' => 'stuff',
+          'foo' => [
+            'bar',
+            'bat',
+            'baz',
+          ],
+        ];
+        $result = $this->callMethod($client, 'buildUrl', [$testParams]);
+        $this->assertEquals($result, 'https://localhost:4010/?thing=stuff&foo=bar&foo=bat&foo=baz');
+    }
+
     /**
      * @param object $obj
      * @param string $name


### PR DESCRIPTION
### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:

A number of APIs accept what is documented as "array of string".  In practice, it's a number of instances of identical URL arguments with different values.

For example from [retrieving subuser reputations](https://sendgrid.com/docs/API_Reference/Web_API_v3/subusers.html#Retrieve-Subuser-Reputations-GET):

```
https://api.sendgrid.com/v3/subusers/reputations?usernames=myfirstsubuser&usernames=mysecondsubuser&usernames=mythirdsubuser
```

I updated the `buildUrl()` function to accept nested arrays so that you could form the above URL with the query:

```php
$queryParams = [
  'usernames' => [
    'myfirstsubuser',
    'mysecondsubuser',
    'mythirdsubuser',
  ],
];
```

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
