### PR TITLE
fix: Composer configuration, typos and type hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6"
+        "php": ">=5.6",
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -123,14 +123,14 @@ use SendGrid\Exception\InvalidRequest;
  * @method Client subusers()
  * @method Client reputations()
  *
- * Supressions
+ * Suppressions
  * @method Client suppression()
  * @method Client global()
  * @method Client blocks()
  * @method Client bounces()
  * @method Client invalid_emails()
  * @method Client spam_reports()
- * @method Client unsubcribes()
+ * @method Client unsubscribes()
  *
  * Templates
  * @method Client templates()
@@ -432,6 +432,7 @@ class Client
      * @param array  $headers         original headers
      *
      * @return Response response object
+     * @throws InvalidRequest
      */
     private function retryRequest(array $responseHeaders, $method, $url, $body, $headers)
     {
@@ -562,6 +563,7 @@ class Client
      * @param array  $args parameters passed with the method call
      *
      * @return Client|Response|Response[]|null object
+     * @throws InvalidRequest
      */
     public function __call($name, $args)
     {

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -16,11 +16,11 @@ use SendGrid\Exception\InvalidRequest;
  *
  * Quickly and easily access any REST or REST-like API.
  *
- * @method Response get($body = null, $query = null, $headers = null)
- * @method Response post($body = null, $query = null, $headers = null)
- * @method Response patch($body = null, $query = null, $headers = null)
- * @method Response put($body = null, $query = null, $headers = null)
- * @method Response delete($body = null, $query = null, $headers = null)
+ * @method Response get($body = null, $query = null, $headers = null, $retryOnLimit = null)
+ * @method Response post($body = null, $query = null, $headers = null, $retryOnLimit = null)
+ * @method Response patch($body = null, $query = null, $headers = null, $retryOnLimit = null)
+ * @method Response put($body = null, $query = null, $headers = null, $retryOnLimit = null)
+ * @method Response delete($body = null, $query = null, $headers = null, $retryOnLimit = null)
  *
  * @method Client version($value)
  * @method Client|Response send()

--- a/lib/Exception/InvalidRequest.php
+++ b/lib/Exception/InvalidRequest.php
@@ -12,7 +12,7 @@ use Throwable;
  *
  * Thrown when invalid payload was constructed, which could not reach SendGrid server.
  *
- * @package SendGrid\Exceptions
+ * @package SendGrid\Exception
  */
 class InvalidRequest extends \Exception
 {


### PR DESCRIPTION
Just came to submit a typo, but I found a few small issues while reviewing this library using phpStorm:
- Usage of `Throwable` when using PHP 5.6 (which is minimal PHP version requirement for this library, I reported it in separate issue)
- Added Composer extension requirements (json, curl)
- Client: magic method 'unsubcribes' -> 'unsubscribes'
- Exception throw blocks
- Typos

ps. In addition of this, I've found missing 4th argument of magic `get()` method in [example.php](https://github.com/sendgrid/php-http-client/blob/master/examples/example.php#L26):
`$response = $client->api_keys()->get(null, $queryParams, $requestHeaders, $retryOnLimit);`
Not a big thing. Just mentioning.

### Checklist
- [X] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the master branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified