### PR TITLE
fix: replace Throwable with Exception

### DIFF
--- a/lib/Exception/InvalidRequest.php
+++ b/lib/Exception/InvalidRequest.php
@@ -1,11 +1,6 @@
 <?php
 
-/**
- * HTTP Client library
- */
 namespace SendGrid\Exception;
-
-use Throwable;
 
 /**
  * Class InvalidHttpRequest
@@ -19,11 +14,11 @@ class InvalidRequest extends \Exception
     public function __construct(
         $message = "",
         $code = 0,
-        Throwable $previous = null
-    ) {
-        $message = 'Could not send request to server. '.
-            'CURL error '.$code.': '.$message;
+        \Exception $previous = null
+    )
+    {
+        $message = 'Could not send request to server. ' .
+            'CURL error ' . $code . ': ' . $message;
         parent::__construct($message, $code, $previous);
     }
-
 }


### PR DESCRIPTION
Fixes https://github.com/sendgrid/php-http-client/issues/142

Throwable was not added until PHP 7 but we still support PHP 5.6 so this needed to be replaced.