### PR TITLE
chore: Add missing method annotation `validations`

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -145,6 +145,7 @@ use SendGrid\Exception\InvalidRequest;
  * @method Client user()
  * @method Client account()
  * @method Client credits()
+ * @method Client validations()
  * @method Client email()
  * @method Client password()
  * @method Client profile()

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -73,6 +73,10 @@ use SendGrid\Exception\InvalidRequest;
  * @method Client field_definitions()
  * @method Client segments()
  * @method Client singlesends()
+ * @method Client contactdb()
+ * @method Client recipients()
+ * @method Client status()
+ * @method Client billable_count()
  *
  * Devices
  * @method Client devices()
@@ -202,7 +206,7 @@ class Client
      * @var bool
      */
     protected $verifySSLCerts;
-    
+
     /**
      * @var bool
      */


### PR DESCRIPTION
Hi @rakatyal, @childish-sambino, @JenniferMah 

# Fixes #

When using the validation/email endpoint, the php code is the following one:
```
$sg->client->validations()->email()->post($request_body);
```
cf the doc https://docs.sendgrid.com/api-reference/e-mail-address-validation/validate-an-email

But there is no autocompletion because of a missing `@method` annotation.
`@method email()` was already added, but not `@method validations` ; This PR fix this.

Same for method related to the following chapter
https://docs.sendgrid.com/api-reference/contacts-api-recipients/add-recipients

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/php-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
-  I have added tests that prove my fix is effective or that my feature works
-  I have added the necessary documentation about the functionality in the appropriate .md file
-  I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
