### PR TITLE
Add support for "Get Contacts by Emails" endpoint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-Hello! Thank you for choosing to help contribute to one of the SendGrid open source projects. There are many ways you can contribute and help is always welcome.  We merely ask that you follow the following contribution policies.
+Hello! Thank you for choosing to help contribute to one of the SendGrid open source projects. There are many ways you can contribute and help is always welcome. We merely ask that you follow the following contribution policies.
 
 - [Improvements to the Codebase](#improvements-to-the-codebase)
 - [Understanding the Code Base](#understanding-the-codebase)
@@ -61,7 +61,7 @@ An HTTP client with a fluent interface using method chaining and reflection. By 
 
 This allows for the following mapping from a URL to a method chain:
 
-`/api_client/{api_key_id}/version` maps to `client->api_client().->_($api_key_id)->version-><method>()` where <method> is a [HTTP verb](lib/Client.php#L210).
+`/api_client/{api_key_id}/version` maps to `$client->api_client()->_($api_key_id)->version-><method>()` where <method> is a [HTTP verb](lib/Client.php#L210).
 
 **/lib/SendGrid/Config.php**
 

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -66,6 +66,7 @@ use SendGrid\Exception\InvalidRequest;
  * Marketing
  * @method Client marketing()
  * @method Client contacts()
+ * @method Client emails()
  * @method Client count()
  * @method Client exports()
  * @method Client imports()


### PR DESCRIPTION
# Fixes #

Makes the [Get contacts by emails](https://docs.sendgrid.com/api-reference/contacts/get-contacts-by-emails) endpoint usable by adding the relative phpDoc method.


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/php-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified
