### PR TITLE
fix: implicitly nullable parameter deprecation in PHP 8.4

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1' ]
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
         dependencies:
           - "lowest"
           - "highest"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ We welcome direct contributions to the php-http-client code base. Thank you!
 
 ##### Prerequisites #####
 
-- PHP version 7.3, 7.4, 8.0, or 8.1
+- PHP version 7.3+
 - [Composer](https://getcomposer.org/)
 
 ##### Initial setup: #####

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2023, Twilio SendGrid, Inc. <help@twilio.com>
+Copyright (C) 2025, Twilio SendGrid, Inc. <help@twilio.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ All updates to this library are documented in our [CHANGELOG](CHANGELOG.md).
 
 ## Prerequisites
 
-- PHP version 7.3, 7.4, 8.0, or 8.1
+- PHP version 7.3+
 
 ## Install with Composer
 

--- a/lib/Exception/InvalidRequest.php
+++ b/lib/Exception/InvalidRequest.php
@@ -12,7 +12,7 @@ class InvalidRequest extends \Exception
     public function __construct(
         $message = '',
         $code = 0,
-        \Exception $previous = null
+        ?\Exception $previous = null
     ) {
         $message = 'Could not send request to server. ' .
             'CURL error ' . $code . ': ' . $message;


### PR DESCRIPTION
Also enabled testing on PHP 8.2, 8.3, and 8.4.