### PR TITLE
chore: fix PHP 8.5 curl_close() deprecation warning

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -529,7 +529,9 @@ class Client
             return $this->retryRequest($responseHeaders, $method, $url, $body, $headers);
         }
 
-        curl_close($channel);
+        if (\PHP_VERSION_ID < 80000) {
+            curl_close($channel);
+        }
 
         return $response;
     }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

[`curl_close()`](https://www.php.net/curl_close) is deprecated in PHP 8.5 and has no effect since PHP 8.0, so guard it with `PHP_VERSION_ID < 80000`.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/php-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
