### PR TITLE
chore: Remove unnecessary curl_close call

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -529,8 +529,6 @@ class Client
             return $this->retryRequest($responseHeaders, $method, $url, $body, $headers);
         }
 
-        curl_close($channel);
-
         return $response;
     }
 


### PR DESCRIPTION
Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0