### PR TITLE
chore: fix php 8.5 deprecation warning

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4', '8.5' ]
         dependencies:
           - "lowest"
           - "highest"

--- a/lib/Client.php
+++ b/lib/Client.php
@@ -529,7 +529,11 @@ class Client
             return $this->retryRequest($responseHeaders, $method, $url, $body, $headers);
         }
 
-        curl_close($channel);
+        if (PHP_VERSION_ID >= 80000) {
+            unset($channel);
+        } else {
+            curl_close($channel);
+        }
 
         return $response;
     }


### PR DESCRIPTION
# Fixes #

Call `unset()` instead of `curl_close()` to prevent PHP 8.5 deprecation errors.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/php-http-client/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).
